### PR TITLE
Fix get current active members

### DIFF
--- a/app/models/semester.rb
+++ b/app/models/semester.rb
@@ -22,4 +22,14 @@ class Semester < ApplicationRecord
   def due_date_before_end_date?
     errors.add :dues_deadline, 'must be before end date' if !dues_deadline.nil? && !end_date.nil? && (end_date < dues_deadline)
   end
+  
+  # returns ID of most recent semester
+  def self.get_current_semester
+    @id = Semester.where('start_date < ?', DateTime.now).order(start_date: :asc).first.id
+	if @id == nil
+	  return Semester.last.id
+	else
+	  return @id
+	end
+  end
 end

--- a/app/models/semester.rb
+++ b/app/models/semester.rb
@@ -26,10 +26,10 @@ class Semester < ApplicationRecord
   # returns ID of most recent semester
   def self.get_current_semester
     @id = Semester.where('start_date < ?', DateTime.now).order(start_date: :asc).first.id
-	if @id == nil
-	  return Semester.last.id
-	else
-	  return @id
-	end
+    if @id == nil
+      return Semester.last.id
+    else
+      return @id
+    end
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -17,7 +17,7 @@
         </li>
         <%if Semester.all.size > 0%>
             <li class="nav-item">
-                <a class="nav-link lead" href=<%=members_path(Semester.last.id)%>>Look at a list of Active Members</a>
+                <a class="nav-link lead" href=<%=members_path(Semester.get_current_semester)%>>Look at a list of Active Members</a>
             </li>
         <%end%>
     </ul>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,7 +7,7 @@
     <h1 class="font-weight-light">Some Links</h1>
     <ul class="nav flex-column">
         <li class="nav-item">
-            <a class="nav-link" href=<%=new_due_path%>>Record a new Payment</a>
+            <a class="nav-link lead" href=<%=new_due_path%>>Record a new Payment</a>
         </li>
         <li class="nav-item">
             <a class="nav-link lead" href=<%=new_member_path%>>Add a Member</a>
@@ -17,7 +17,7 @@
         </li>
         <%if Semester.all.size > 0%>
             <li class="nav-item">
-                <a class="nav-link lead" href=<%=members_path(Semester.get_current_semester)%>>Look at a list of Active Members</a>
+                <a class="nav-link lead" href="/members?semesterId=<%=Semester.get_current_semester%>">Look at a list of Active Members</a>
             </li>
         <%end%>
     </ul>


### PR DESCRIPTION
Fixed the link on the home page to view the current active members so that it's more accurate. Previously it only got the last semester, now it checks the date. 